### PR TITLE
Retry lors de l'écriture en S3 de liens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.2.6
+
+### [Changed]
+
+* `JOINCACHE` : 
+  * L'écriture d'objet symbolique en S3 se fait avec un retry (5 fois, 2 secondes entre chaque tentative)
+
 ## 4.2.5
 
 ### [Fixed]

--- a/lib/ROK4/JOINCACHE/Shell.pm
+++ b/lib/ROK4/JOINCACHE/Shell.pm
@@ -196,7 +196,7 @@ LinkSlab () {
         curl_options="-k"
     fi
 
-    curl $curl_options -s --fail -X PUT -d "SYMLINK#${target}" \
+    curl $curl_options --retry-delay 2 --retry 5 -s --fail -X PUT -d "SYMLINK#${target}" \
      -H "Host: ${HOST}" \
      -H "Date: ${dateValue}" \
      -H "Content-Type: ${contentType}" \


### PR DESCRIPTION
## [Changed]

* `JOINCACHE` : 
    * L'écriture d'objet symbolique en S3 se fait avec un retry (5 fois, 2 secondes entre chaque tentative)