### PR TITLE
Adaptation à la nouvelle gestion des formats dans les outils raster du projet

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,7 @@ Génération d'une nouvelle pyramide depuis des images géoréférencées type M
             "shared_tmp": "/share"
         },
         "parallelization": 1,
-        "style": "/etc/rok4/styles/montagne.json",
-        "nodata": [-99999]
+        "style": "/etc/rok4/styles/montagne.json"
     }
 }
 ```

--- a/bin/be4.pl
+++ b/bin/be4.pl
@@ -560,6 +560,10 @@ sub doIt {
                     push(@{$pyramid->{nodata}}, 0);
                 }
             }
+        }
+
+        if (exists $this{params}->{process}->{style}) {
+            $pyramid->{style} = $this{params}->{process}->{style};
         }  
 
         $this{loaded}->{output_pyramid} = ROK4::Core::PyramidRaster->new("VALUES", $pyramid );

--- a/bin/be4.pl
+++ b/bin/be4.pl
@@ -541,7 +541,7 @@ sub doIt {
 
         if (defined $inputPixel) {
             if (! exists $pyramid->{pixel}->{sampleformat}) {
-                $pyramid->{pixel}->{sampleformat} = $inputPixel->getSampleFormatCode();
+                $pyramid->{pixel}->{sampleformat} = uc($inputPixel->getSampleFormat());
             }
             if (! exists $pyramid->{pixel}->{samplesperpixel}) {
                 $pyramid->{pixel}->{samplesperpixel} = $inputPixel->getSamplesPerPixel();

--- a/bin/joincache.pl
+++ b/bin/joincache.pl
@@ -359,7 +359,7 @@ sub load {
 
     if (defined $inputPixel) {
         if (! exists $this{params}->{pyramid}->{pixel}->{sampleformat}) {
-            $this{params}->{pyramid}->{pixel}->{sampleformat} = $inputPixel->getSampleFormatCode();
+            $this{params}->{pyramid}->{pixel}->{sampleformat} = uc($inputPixel->getSampleFormat());
         }
         if (! exists $this{params}->{pyramid}->{pixel}->{samplesperpixel}) {
             $this{params}->{pyramid}->{pixel}->{samplesperpixel} = $inputPixel->getSamplesPerPixel();

--- a/lib/ROK4/BE4/Shell.pm
+++ b/lib/ROK4/BE4/Shell.pm
@@ -1046,10 +1046,9 @@ sub getScriptInitialization {
         $string .= sprintf "MERGENTIFF_OPTIONS=\"-c zip -i %s -p $style -n %s\"\n", $pyramid->getInterpolation(), join(",", @{$input_nodata});
 
     } else {
-        $string .= sprintf "MERGENTIFF_OPTIONS=\"-c zip -i %s -s %s -b %s -a %s -n %s\"\n",
+        $string .= sprintf "MERGENTIFF_OPTIONS=\"-c zip -i %s -s %s -a %s -n %s\"\n",
             $pyramid->getInterpolation(),
             $pyramid->getPixel()->getSamplesPerPixel(),
-            $pyramid->getPixel()->getBitsPerSample(),
             $pyramid->getPixel()->getSampleFormat(),
             $pyramid->getNodata();
     }
@@ -1060,19 +1059,17 @@ sub getScriptInitialization {
 
     $string .= sprintf "WORK2CACHE_MASK_OPTIONS=\"-c zip -t %s %s\"\n", $pyramid->getTileMatrixSet()->getTileWidth(), $pyramid->getTileMatrixSet()->getTileHeight();
 
-    $string .= sprintf "WORK2CACHE_IMAGE_OPTIONS=\"-c %s -t %s %s -s %s -b %s -a %s\"\n",
+    $string .= sprintf "WORK2CACHE_IMAGE_OPTIONS=\"-c %s -t %s %s -s %s -a %s\"\n",
         $pyramid->getCompression(),
         $pyramid->getTileMatrixSet()->getTileWidth(), $pyramid->getTileMatrixSet()->getTileHeight(),
         $pyramid->getPixel()->getSamplesPerPixel(),
-        $pyramid->getPixel()->getBitsPerSample(),
         $pyramid->getPixel()->getSampleFormat();
 
     if ($pyramid->getTileMatrixSet()->isQTree()) {
-        $string .= sprintf "MERGE4TIFF_OPTIONS=\"-c zip -g %s -n %s -s %s -b %s -a %s\"\n",
+        $string .= sprintf "MERGE4TIFF_OPTIONS=\"-c zip -g %s -n %s -s %s -a %s\"\n",
             $pyramid->getGamma(),
             $pyramid->getNodata(),
             $pyramid->getPixel()->getSamplesPerPixel(),
-            $pyramid->getPixel()->getBitsPerSample(),
             $pyramid->getPixel()->getSampleFormat();
     } else {
         $string .= sprintf "DECIMATENTIFF_OPTIONS=\"-c zip -n %s\"\n", $pyramid->getNodata();

--- a/lib/ROK4/BE4/Shell.pm
+++ b/lib/ROK4/BE4/Shell.pm
@@ -417,6 +417,8 @@ PushSlab () {
             fi
         fi
     fi
+
+    print_prog
 }
 
 PullSlab () {
@@ -482,6 +484,8 @@ PushSlab () {
             fi
         fi
     fi
+
+    print_prog
 }
 
 PullSlab () {
@@ -1028,7 +1032,6 @@ Function: getScriptInitialization
 Parameters (list):
     pyramid - <ROK4::Core::PyramidVector> - Pyramid to generate
     style - string - Chemin du fichier de style à appliquer
-    input_nodata - string - Valeur de nodata dans les données en entrée dans le cas d'un style
 
 Returns:
     Global variables and functions to print into script
@@ -1036,14 +1039,13 @@ Returns:
 sub getScriptInitialization {
     my $pyramid = shift;
     my $style = shift;
-    my $input_nodata = shift;
 
     # Variables
 
     my $string = $WORKANDPROG;
 
-    if (defined $style && defined $input_nodata) {
-        $string .= sprintf "MERGENTIFF_OPTIONS=\"-c zip -i %s -p $style -n %s\"\n", $pyramid->getInterpolation(), join(",", @{$input_nodata});
+    if (defined $style) {
+        $string .= sprintf "MERGENTIFF_OPTIONS=\"-c zip -i %s -p $style\"\n", $pyramid->getInterpolation();
 
     } else {
         $string .= sprintf "MERGENTIFF_OPTIONS=\"-c zip -i %s -s %s -a %s -n %s\"\n",

--- a/lib/ROK4/BE4/be4.schema.json
+++ b/lib/ROK4/BE4/be4.schema.json
@@ -214,7 +214,7 @@
                             "type": "number",
                             "description": "Gamma factor for sub-resampling",
                             "minimum": 0,
-                            "maximum": 1
+                            "maximum": 5
                         },
                         "pixel": {
                             "type": "object",
@@ -354,14 +354,6 @@
                 "style": {
                     "type": "string",
                     "description": "Chemin vers le fichier de style à appliquer aux données en entrée"
-                },
-                "nodata": {
-                    "type": "array",
-                    "description": "Valeur de nodata dans les données en entrée, utile lors de l'application d'un style",
-                    "items": {
-                        "type": "integer"
-                    },
-                    "minItems": 1
                 },
                 "parallelization": {
                     "type": "integer",

--- a/lib/ROK4/FOURALAMO/Node.pm
+++ b/lib/ROK4/FOURALAMO/Node.pm
@@ -346,15 +346,8 @@ sub makeJsons {
     my @tables = $datasource->getSource()->getSqlExports();
 
     my @tmp = $this->getBBox(TRUE);
-    if ($this->getLevel() eq "0") {
-        INFO(join(",", @tmp));
-    }
 
     my @bbox = ROK4::Core::ProxyGDAL::convertBBox( $this->getGraph()->getCoordTransPyramidDatasource(), $this->getBBox(TRUE));
-
-    if ($this->getLevel() eq "0") {
-        INFO(Dumper(\@bbox));
-    }
 
     # On va agrandir la bbox de 5% pour être sur de tout avoir
     my @bbox_extended = @bbox;
@@ -364,10 +357,6 @@ sub makeJsons {
     $bbox_extended[2] += $w;
     $bbox_extended[1] -= $h;
     $bbox_extended[3] += $h;
-
-    if ($this->getLevel() eq "0") {
-        INFO(Dumper(\@bbox_extended));
-    }
 
     my $bbox_ext_string = join(" ", @bbox_extended);
     my $bbox_string = join(" ", @bbox);

--- a/lib/ROK4/JOINCACHE/Shell.pm
+++ b/lib/ROK4/JOINCACHE/Shell.pm
@@ -651,11 +651,10 @@ sub getScriptInitialization {
 
     $string .= sprintf "WORK2CACHE_MASK_OPTIONS=\"-c zip -t %s %s\"\n", $pyramid->getTileMatrixSet()->getTileWidth(), $pyramid->getTileMatrixSet()->getTileHeight();
 
-    $string .= sprintf "WORK2CACHE_IMAGE_OPTIONS=\"-c %s -t %s %s -s %s -b %s -a %s\"\n",
+    $string .= sprintf "WORK2CACHE_IMAGE_OPTIONS=\"-c %s -t %s %s -s %s -a %s\"\n",
         $pyramid->getCompression(),
         $pyramid->getTileMatrixSet()->getTileWidth(), $pyramid->getTileMatrixSet()->getTileHeight(),
         $pyramid->getPixel()->getSamplesPerPixel(),
-        $pyramid->getPixel()->getBitsPerSample(),
         $pyramid->getPixel()->getSampleFormat();
 
     if ($pyramid->getStorageType() eq "FILE") {

--- a/lib/ROK4/PREGENERATION/Forest.pm
+++ b/lib/ROK4/PREGENERATION/Forest.pm
@@ -196,8 +196,7 @@ sub _load {
 
         $scriptInit = ROK4::BE4::Shell::getScriptInitialization(
             $this->{pyramid},
-            $params->{style},
-            $params->{nodata}
+            $params->{style}
         );
     } else {
         if (! ROK4::FOURALAMO::Shell::setGlobals($params)) {


### PR DESCRIPTION
### [Changed]

* `be4` : 
    * on ne précise plus de nodata dans le cas d'application d'un style (ce dernier en contient déjà un)
    * on compare les sample format avec la nouvelle version
* `joincache` : 
    * on utilise les sample format avec la nouvelle version (qui contient le nombre de bits)