### PR TITLE
Optimisation de l'outil 4alamo

### DIFF
--- a/lib/ROK4/PREGENERATION/Source.pm
+++ b/lib/ROK4/PREGENERATION/Source.pm
@@ -296,6 +296,14 @@ sub _load {
         $this->{bbox} = [$xmin,$ymin,$xmax,$ymax];
     }
 
+    if ($this->{type} eq "POSTGRESQL") {
+        # On va récupérer les statistiques sur les attributs, en se limitant à la bbox demandée
+        if (! $this->{database}->analyse($this->{bbox})) {
+            ERROR("Cannot analyse a POSTGRESQL source");
+            return FALSE;
+        }
+    }
+
     return TRUE;
 }
 


### PR DESCRIPTION
### [Added]

* `4alamo` :
    * on limite la récupération des statistiques sur les attributs à la zone de calcul
    * on n'extraie les données que sur l'intersetion de la dalle et de la zone de calcul
    * on force les gémétries en 2 dimensions
    * on force la multi géométrie si les deux sont présents
    * on applique une validation sur les géométries lors de l'export