### PR TITLE
feat: add wget timeout to wms2work

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Leur définition est contrôlée à l'usage.
     - `HTTP_PROXY`
     - `HTTPS_PROXY`
     - `NO_PROXY`
+* Pour le moissonage WMS, le timeout du wget est paramétrable via `WMS2WORK_WGET_TIMEOUT`. Sa valeur doit respecter le format autorisé par la commande Unix `timeout`. (Valeur par défaut: `60s`)
 
 ## Présentation des outils
 

--- a/lib/ROK4/BE4/Shell.pm
+++ b/lib/ROK4/BE4/Shell.pm
@@ -599,7 +599,7 @@ Wms2work () {
         while :
         do
             let count=count+1
-            wget --no-verbose -O $nameImg "$url&BBOX=$1"
+            timeout ${WMS2WORK_WGET_TIMEOUT} wget --no-verbose -O $nameImg "$url&BBOX=$1"
 
             if [ $? == 0 ] ; then
                 checkWork $nameImg 2>/dev/null

--- a/lib/ROK4/PREGENERATION/Script.pm
+++ b/lib/ROK4/PREGENERATION/Script.pm
@@ -227,6 +227,9 @@ sub prepare {
     $code .= "# Création du dossier temporaire\n";
     $code .= "mkdir -p \${TMP_DIR}\n\n";
 
+    $code .= "# Timeout du wget de la fonction Wms2work\n";
+    $code .= sprintf ("WMS2WORK_WGET_TIMEOUT=\"%s\"\n", $ENV{WMS2WORK_WGET_TIMEOUT} || '60s');
+
     if (defined $initialisation) {
         $code .= $initialisation;
     }


### PR DESCRIPTION
Lors du moissonnage, il arrive que l'exécution de la commande `wget` reste bloquée.
L'ajout d'un timeout permet de limiter cet effet.